### PR TITLE
add comment for parser2 attriabutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,10 @@ module: {
 'html-minify-loader': {
      empty: true,        // KEEP empty attributes
      cdata: true,        // KEEP CDATA from scripts
-     comments: true     // KEEP comments
+     comments: true,     // KEEP comments
+     dom: {                            // options of !(htmlparser2)[https://github.com/fb55/htmlparser2]
+            lowerCaseAttributeNames: false,      // do not call .toLowerCase for each attribute name (Angular2 use camelCase attributes)
+     }
 }
 
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "html-minify-loader",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Loader for webpack that minifies HTML using (minimize)[https://github.com/Moveo/minimize]",
   "main": "index.js",
   "repository": {
@@ -14,6 +14,6 @@
   },
   "homepage": "https://github.com/bestander/html-minify-loader",
   "dependencies": {
-    "minimize": "^1.3.3"
+    "minimize": "^1.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "html-minify-loader",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "Loader for webpack that minifies HTML using (minimize)[https://github.com/Moveo/minimize]",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Minimize recently updated its version from 1.7.4 to 1.7.5 (now 1.8.1). It can pass option into 'htmlparser2' now. Angular2 beta use attribute 'ngIf', if use Minimize version 1.7.4 or before, it would be changed to lowercase. To fix it updating to 1.7.5 above and added lowerCaseAttributeNames option.  

I hope this is a good reason to add a pull request.
